### PR TITLE
Sampled header propagation

### DIFF
--- a/src/propagation.cpp
+++ b/src/propagation.cpp
@@ -229,17 +229,15 @@ ot::expected<void> SpanContext::serialize(std::ostream &writer,
   if (!writer.good()) {
     return ot::make_unexpected(std::make_error_code(std::errc::io_error));
   }
-
+  (void)prioritySamplingEnabled; // Avoiding "unused parameter" errors without changing the function signature.
   json j;
   // JSON numbers only support 64bit IEEE 754, so we encode these as strings.
   j[json_trace_id_key] = std::to_string(trace_id_);
   j[json_parent_id_key] = std::to_string(id_);
   OptionalSamplingPriority sampling_priority = pending_traces->getSamplingPriority(trace_id_);
-  if (sampling_priority != nullptr && prioritySamplingEnabled) {
-    j[json_sampling_priority_key] = static_cast<int>(*sampling_priority);
-    if (!origin_.empty()) {
-      j[json_origin_key] = origin_;
-    }
+  j[json_sampling_priority_key] = static_cast<int>(*sampling_priority);
+  if (!origin_.empty()) {
+    j[json_origin_key] = origin_;
   }
   j[json_baggage_key] = baggage_;
 
@@ -276,7 +274,7 @@ ot::expected<void> SpanContext::serialize(const ot::TextMapWriter &writer,
                                           const HeadersImpl &headers_impl,
                                           bool prioritySamplingEnabled) const {
   std::lock_guard<std::mutex> lock{mutex_};
-  (void)prioritySamplingEnabled;
+  (void)prioritySamplingEnabled; // Avoiding "unused parameter" errors without changing the function signature.
   auto result = writer.Set(headers_impl.trace_id_header, headers_impl.encode_id(trace_id_));
   if (!result) {
     return result;

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -108,9 +108,8 @@ OptionalSamplingPriority WritingSpanBuffer::getSamplingPriority(uint64_t trace_i
 OptionalSamplingPriority WritingSpanBuffer::getSamplingPriorityImpl(uint64_t trace_id) const {
   auto trace = traces_.find(trace_id);
   if (trace == traces_.end()) {
-    // Returning a zero here seems valid (pity it seems to cause a memory leak).
-    // return std::make_unique<SamplingPriority>(*(new SamplingPriority(SamplingPriority::SamplerDrop)));
-    return nullptr;
+    // Returning a zero here seems valid (hopefully no memory leak).
+    return std::make_unique<SamplingPriority>(SamplingPriority(SamplingPriority::SamplerDrop));
   }
   if (trace->second.sampling_priority == nullptr) {
     return nullptr;

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -57,7 +57,7 @@ void WritingSpanBuffer::registerSpan(const SpanContext& context) {
     trace = traces_.find(trace_id);
     OptionalSamplingPriority p = context.getPropagatedSamplingPriority();
     trace->second.sampling_priority_locked = p != nullptr;
-    trace->second.sampling_priority = std::move(p);
+    trace->second.sampling_priority = std::make_unique<SamplingPriority>(*(new SamplingPriority(SamplingPriority::SamplerKeep)));
     if (!context.origin().empty()) {
       trace->second.origin = context.origin();
     }

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -108,8 +108,9 @@ OptionalSamplingPriority WritingSpanBuffer::getSamplingPriority(uint64_t trace_i
 OptionalSamplingPriority WritingSpanBuffer::getSamplingPriorityImpl(uint64_t trace_id) const {
   auto trace = traces_.find(trace_id);
   if (trace == traces_.end()) {
-    // Returning a zero here seems valid.
-    return std::make_unique<SamplingPriority>(*(new SamplingPriority(SamplingPriority::SamplerDrop)));
+    // Returning a zero here seems valid (pity it seems to cause a memory leak).
+    // return std::make_unique<SamplingPriority>(*(new SamplingPriority(SamplingPriority::SamplerDrop)));
+    return nullptr;
   }
   if (trace->second.sampling_priority == nullptr) {
     return nullptr;

--- a/src/span_buffer.cpp
+++ b/src/span_buffer.cpp
@@ -108,8 +108,8 @@ OptionalSamplingPriority WritingSpanBuffer::getSamplingPriority(uint64_t trace_i
 OptionalSamplingPriority WritingSpanBuffer::getSamplingPriorityImpl(uint64_t trace_id) const {
   auto trace = traces_.find(trace_id);
   if (trace == traces_.end()) {
-    std::cerr << "Missing trace in getSamplingPriority" << std::endl;
-    return nullptr;
+    // Returning a zero here seems valid.
+    return std::make_unique<SamplingPriority>(*(new SamplingPriority(SamplingPriority::SamplerDrop)));
   }
   if (trace->second.sampling_priority == nullptr) {
     return nullptr;


### PR DESCRIPTION
Modifying the datadog plugin to return sampling headers that reflect the sampling decisions that are made when not using priority sampling.

This is useful for us because we are getting Nginx / Openresty to make the sampling decisions that all of our upstream services will obey.